### PR TITLE
Embed Gitpod setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,13 +3,16 @@ image: drupalpod/drupalpod-gitpod-base:20220311
 # ddev and composer are running as part of the prebuild
 # when starting a Gitpod workspace all docker images are ready
 tasks:
-  - init: |
+  - name: parepare
+    init: |
       time ddev debug download-images
       time .gitpod/project-setup.sh
     command: |
       ddev start -y
       ddev exec npm run watch 
-  - command: |
+  - name: terminal
+    openMode: split-left
+    command: |
       gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
       echo "The system is ready"
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,19 +1,17 @@
 image: drupalpod/drupalpod-gitpod-base:20220311
 
 # ddev and composer are running as part of the prebuild
-# when starting a workspace all docker images are ready
+# when starting a Gitpod workspace all docker images are ready
 tasks:
   - init: |
       time ddev debug download-images
       time .gitpod/project-setup.sh
     command: |
-      gp sync-await prepare
-      gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
-      echo "The system is ready"
-  - command: |
       ddev start -y
       ddev exec npm run watch 
-      gp sync-done prepare
+  - command: |
+      gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+      echo "The system is ready"
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,9 +7,13 @@ tasks:
       time ddev debug download-images
       time .gitpod/project-setup.sh
     command: |
-      ddev start -y
+      gp sync-await prepare
       gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
       echo "The system is ready"
+  - command: |
+      ddev start -y
+      ddev exec npm run watch 
+      gp sync-done prepare
 
 vscode:
   extensions:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,69 @@
+image: drupalpod/drupalpod-gitpod-base:20220311
+
+# ddev and composer are running as part of the prebuild
+# when starting a workspace all docker images are ready
+tasks:
+  - init: |
+      time ddev debug download-images
+      time .gitpod/project-setup.sh
+    command: |
+      ddev start -y
+      gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+      echo "The system is ready"
+
+vscode:
+  extensions:
+    # PHP extensions.
+    - felixfbecker.php-debug
+    - wongjn.php-sniffer
+    - neilbrayfield.php-docblocker
+    - bmewburn.vscode-intelephense-client
+
+    # Bash extensions.
+    - timonwong.shellcheck
+    - rogalmic.bash-debug
+
+ports:
+  # Used by ddev - local db clients
+  - port: 3306
+    onOpen: ignore
+  # Used by projector
+  - port: 6942
+    onOpen: ignore
+  # Used by MailHog
+  - port: 8027
+    onOpen: ignore
+  # Used by phpMyAdmin
+  - port: 8036
+    onOpen: ignore
+  # Direct-connect ddev-webserver port that is the main port
+  - port: 8080
+    onOpen: ignore
+  # Ignore host https port
+  - port: 8443
+    onOpen: ignore
+  # xdebug port
+  - port: 9003
+    onOpen: ignore
+  # projector port
+  - port: 9999
+    onOpen: open-browser
+
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: false
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: true
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: true

--- a/.gitpod/project-setup.sh
+++ b/.gitpod/project-setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+# Prepare vscode-xdebug setup
+mkdir -p .vscode
+cp .gitpod/templates/launch.json .vscode/.
+
+# Prepare Laravel website
+ddev composer install
+ddev exec "cat .env.example | sed  -E 's/DB_(HOST|DATABASE|USERNAME|PASSWORD)=(.*)/DB_\1=db/g' > .env"
+ddev artisan key:generate
+ddev artisan migrate
+ddev exec npm install

--- a/.gitpod/templates/launch.json
+++ b/.gitpod/templates/launch.json
@@ -1,0 +1,26 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+    {
+        "name": "Listen for XDebug",
+        "type": "php",
+        "request": "launch",
+        "hostname": "0.0.0.0",
+        "port": 9003,
+        "pathMappings": {
+            "/var/www/html": "${workspaceRoot}"
+        }
+    },
+    {
+        "type": "bashdb",
+        "request": "launch",
+        "name": "Bash-Debug (select script from list of sh files)",
+        "cwd": "${workspaceFolder}",
+        "program": "${command:SelectScriptName}",
+        "args": []
+    }
+    ]
+}


### PR DESCRIPTION
I love `ddev-gitpod-launcher`, but I also think once projects experience the magic and simplicity, they can go the next step, and integrate Gitpod setup in their repo.
The main benefit - Gitpod prebuilds, every commit or PR signal Gitpod to prepare the project in the background (download ddev images, `composer install`, `npm install`, etc.). Users who open that branch in Gitpod, would get the working workspace much faster.

This PR embed Gitpod setup in the project repo, and anyone who clone it as a starting point, would benefit from the setup as well.